### PR TITLE
Save task data in solution

### DIFF
--- a/basic-client/taskGiver.js
+++ b/basic-client/taskGiver.js
@@ -97,6 +97,7 @@ module.exports = {
 								try {
 
 									const solution = toSolution(await incentiveLayer.getSolution.call(taskID))
+									solution["data"] = web3.utils.hexToBytes(taskData.taskData)
 
 									if (solution.finalized) {
 										fs.writeFile("solutions/" + taskID + ".json", JSON.stringify(solution), (err) => { if (err) console.log(err)})


### PR DESCRIPTION
This saves the task data alongside the solution. For example, a logging service could reproduce individual steps of the solution.

Before:
```json
{
  "solution": "0x0000000000000000000000000000000000000000000000000000000000000024",
  "finalized": true
}
```

After:
```json
{
  "solution": "0x0000000000000000000000000000000000000000000000000000000000000024",
  "finalized": true,
  "data": [
    1,2,3,4,5,6,7,8,9
  ]
}
```