### PR TITLE
Fix error converting byte array to bytes32 when submitting task

### DIFF
--- a/basic-client/taskSubmitter.js
+++ b/basic-client/taskSubmitter.js
@@ -20,9 +20,12 @@ module.exports = (web3) => {
     
             await depositsHelper(web3, incentiveLayer, task.from, task.minDeposit)
     
+            // Incentive layer is restricted to bytes32 for task data
+            taskData = web3.utils.bytesToHex(task.data)
+
             tx = await incentiveLayer.createTask(
                 task.minDeposit,
-                task.data,
+                taskData,
                 task.intervals,
                 task.data.length,
                 drlConfig["BasicVerificationGame"].address,


### PR DESCRIPTION
The incentive layer uses bytes32 to represent the task data, I assume due to the difficulties of storing and returning a dynamic byte array (the code suggests using a content-addressed storage hash). When the task submitter creates a task, it needs to convert the task data from a byte array to the bytes32 expected by the incentive layer.

The solution is still wrong, but by applying #5, you can see that the task data is read back correctly:

Before:
```json
{
  "solution": "0x00000000000000000000000000000000000000000000000000000000000001d5",
  "finalized": true,
  "data": [
    91,49,44,50,44,51,44,52,44,53,44,54,44,55,44,56,44,57,93
  ]
}
```

After:
```json
{
  "solution": "0x0000000000000000000000000000000000000000000000000000000000000024",
  "finalized": true,
  "data": [
    1,2,3,4,5,6,7,8,9
  ]
}
```