### PR TITLE
Add Travis CI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "basic-client/incentive-layer"]
 	path = basic-client/incentive-layer
-	url = git@github.com:TrueBitFoundation/incentive-layer.git
+	url = https://github.com/TrueBitFoundation/incentive-layer.git
 [submodule "basic-client/dispute-resolution-layer"]
 	path = basic-client/dispute-resolution-layer
-	url = git@github.com:TrueBitFoundation/dispute-resolution-layer.git
+	url = https://github.com/TrueBitFoundation/dispute-resolution-layer.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
 
 before_install:
   - npm i -g ganache-cli truffle
-  - ganache-cli &>/dev/null 
+  - ganache-cli &>/dev/null &
 
 install:
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
 
 install:
   - npm install
+  - chmod 755 basic-client/install.sh basic-client/deploy.sh
   - ./basic-client/install.sh
   - ./basic-client/deploy.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
     - "node_modules"
 
 before_install:
-  - npm i -g ganache-cli
+  - npm i -g ganache-cli truffle
   - ganache-cli &
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: node_js
+node_js:
+  - "8"
+cache:
+  directories:
+    - "node_modules"
+
+before_install:
+  - npm i -g ganache-cli
+  - ganache-cli &
+
+install:
+  - npm install
+  - ./basic-client/install.sh
+  - ./basic-client/deploy.sh
+
+script:
+  - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
 
 before_install:
   - npm i -g ganache-cli truffle
-  - ganache-cli &
+  - ganache-cli &>/dev/null 
 
 install:
   - npm install

--- a/test/os.js
+++ b/test/os.js
@@ -12,7 +12,7 @@ let os
 let taskSubmitter
 
 before(async () => {
-	os = await require('../os/kernel')("config.json")
+	os = await require('../os/kernel')("./basic-client/config.json")
 	taskSubmitter = require('../basic-client/taskSubmitter')(os.web3)
 })
 


### PR DESCRIPTION
I've added Travis CI. You can see it passing on my fork:

https://travis-ci.org/OR13/truebit-os/builds/378927391

In order to do this, I had to change .gitmodules to use https instead of ssh, and fix a path issue in the mocha test.

Having CI will help encourage contributions :)