### PR TITLE
Fix Travis Submodule Errors

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/TrueBitFoundation/dispute-resolution-layer.git
 [submodule "wasm-client/ocaml-offchain"]
 	path = wasm-client/ocaml-offchain
-	url = git@github.com:TrueBitFoundation/ocaml-offchain.git
+	url = https://github.com/TrueBitFoundation/ocaml-offchain.git
 [submodule "wasm-client/webasm-solidity"]
 	path = wasm-client/webasm-solidity
-	url = git@github.com:TrueBitFoundation/webasm-solidity.git
+	url = https://github.com/TrueBitFoundation/webasm-solidity.git


### PR DESCRIPTION
Current .gitmodules includes git@github.com/TrueBit which requires login, 

Changed to https://github.com/ URLS so that Travis doesn't error