### PR TITLE
Working on refactoring scrypt test to be more inline with other tests

### DIFF
--- a/test/os-wasm-alphabet.js
+++ b/test/os-wasm-alphabet.js
@@ -17,9 +17,7 @@ const ipfs = require('ipfs-api')(host, '5001', {protocol: 'http'})
 
 const fileSystem = merkleComputer.fileSystem(ipfs)
 
-let os
-
-let taskSubmitter
+let os, taskSubmitter
 
 before(async () => {
     os = await require('../os/kernel')("./wasm-client/config.json")
@@ -76,15 +74,7 @@ describe('Truebit OS WASM Alphabet', async function() {
 
 	it('should submit task', async () => {
 
-	    let exampleTask = {
-		"minDeposit": "1",
-		"codeType": "WASM",
-		"storageType": "IPFS",
-		"codeFile": "/data/reverse_alphabet.wasm",
-		"reward": "0",
-		"files": ["/data/alphabet.txt", "/data/reverse_alphabet.txt"]
-	    }
-
+	    let exampleTask = JSON.parse(fs.readFileSync("testWasmAlphabet.json"))
 	    //simulate cli by adding from account and translate reward
 
 	    exampleTask["from"] = os.accounts[0]

--- a/test/os-wasm-scrypt.js
+++ b/test/os-wasm-scrypt.js
@@ -1,52 +1,23 @@
 const assert = require('assert')
-
 const timeout = require('../os/lib/util/timeout')
-
 const BigNumber = require('bignumber.js')
-
 const mineBlocks = require('../os/lib/util/mineBlocks')
-
 const fs = require('fs')
-
 const logger = require('../os/logger')
-const contract = require('../wasm-client/contractHelper')
-var truffle_contract = require("truffle-contract");
 
 const contractsConfig = JSON.parse(fs.readFileSync("./wasm-client/contracts.json"))
 
 const merkleComputer = require('../wasm-client/merkle-computer')()
 
-// const wasmClientConfig = JSON.parse(fs.readFileSync("./wasm-client/webasm-solidity/export/development.json"))
-
-let os
+let os, taskSubmitter
 
 const config = JSON.parse(fs.readFileSync("./wasm-client/config.json"))
 const info = JSON.parse(fs.readFileSync("./scrypt-data/info.json"))
 const ipfs = require('ipfs-api')(config.ipfs.host, '5001', {protocol: 'http'})
 const fileSystem = merkleComputer.fileSystem(ipfs)
 
-function arrange(arr) {
-    let res = []
-    let acc = ""
-    arr.forEach(function (b) { acc += b; if (acc.length == 64) { res.push("0x"+acc); acc = "" } })
-    if (acc != "") res.push("0x"+acc)
-    console.log(res)
-    return res
-}
-
-function stringToBytes(str) {
-    return "0x" + Buffer.from(str).toString("hex")
-}
-
-let account
-let web3
-
-
 before(async () => {
     os = await require('../os/kernel')("./wasm-client/config.json")
-    account = os.accounts[0]
-    
-    web3 = os.web3
 })
 
 describe('Truebit OS WASM Scrypt test', async function() {
@@ -64,23 +35,8 @@ describe('Truebit OS WASM Scrypt test', async function() {
     	assert(os.solver)
     })
     
-    let tbFilesystem, tru
-    
-    async function createFile(fname, buf) {
-        var nonce = await web3.eth.getTransactionCount(config.base)
-        var arr = []
-        for (var i = 0; i < buf.length; i++) {
-            if (buf[i] > 15) arr.push(buf[i].toString(16))
-            else arr.push("0" + buf[i].toString(16))
-        }
-        console.log("Nonce", nonce, {arr:arrange(arr)})
-        var tx = await filesystem.createFileWithContents(fname, nonce, arrange(arr), buf.length, {from:account})
-        var id = await filesystem.calcId.call(nonce, {from:account})
-        return id
-    }
-
     describe('Normal task lifecycle', async () => {
-	let killSolver
+	let killSolver, killTaskGiver
 
 	let taskID
 	
@@ -89,63 +45,78 @@ describe('Truebit OS WASM Scrypt test', async function() {
 	let storageAddress, initStateHash, bundleID
 
 	before(async () => {
-        tbFilesystem = await contract(web3.currentProvider, contractsConfig['fileSystem'])
-        tru = await contract(web3.currentProvider, contractsConfig['tru'])
+	    taskSubmitter = await require('../wasm-client/taskSubmitter')(os.web3, os.logger, fileSystem)
+            killTaskGiver = await os.taskGiver.init(os.web3, os.accounts[0], os.logger)
 	    killSolver = await os.solver.init(os.web3, os.accounts[1], os.logger, fileSystem)
 	})
 
 	after(() => {
-        console.log("here")
+	    killTaskGiver()
 	    killSolver()
 	})
 
-	it('should upload task code', async () => {
-        let codeBuf = fs.readFileSync("./scrypt-data/task.wasm")
-        let ipfsHash = (await fileSystem.upload(codeBuf, "task.wasm"))[0].hash
-        
-        assert.equal(ipfsHash, info.ipfshash)
-    })
-    
-    let scrypt_contract
-    let scrypt_result
-
-	it('should deploy test contract', async () => {
-        let MyContract = truffle_contract({
-            abi: JSON.parse(fs.readFileSync("./scrypt-data/compiled/Scrypt.abi")),
-            unlinked_binary: fs.readFileSync("./scrypt-data/compiled/Scrypt.bin"),
-        })
-        MyContract.setProvider(web3.currentProvider)
-
-        scrypt_contract = await MyContract.new(contractsConfig.incentiveLayer.address, contractsConfig.tru.address, contractsConfig.fileSystem.address, info.ipfshash, info.codehash, {from:account, gas:2000000})
-        let result_event = scrypt_contract.GotFiles()
-        result_event.watch(async (err, result) => {
-            console.log("got event, file ID", result.args.files[0])
-            result_event.stopWatching(data => {})
-            let fileid = result.args.files[0]
-            var lst = await tbFilesystem.getData(fileid)
-            console.log("got stuff", lst)
-            scrypt_result = lst[0]
-        })
-        tru.transfer(scrypt_contract.address, "100000000000", {from:account, gas:200000})
-    })
-    
 	it('should submit task', async () => {
-        scrypt_contract.submitData("testing", {from:account, gas:2000000})
-    })
+	    let exampleTask = JSON.parse(fs.readFileSync("testWasmScrypt.json"))
 
-    it('wait for task', async () => {
+	    //simulate cli by adding account and translating reward
+	    exampleTask["from"] = os.accounts[0]
+	    exampleTask["reward"] = os.web3.utils.toWei(exampleTask.reward, 'ether')
+	    await taskSubmitter.submitTask(exampleTask)
 
-	    await timeout(15000)
-	    await mineBlocks(os.web3, 110)
 	    await timeout(5000)
 	    await mineBlocks(os.web3, 110)
 	    await timeout(5000)
-        
 	    await mineBlocks(os.web3, 110)
 	    await timeout(5000)
-        
-        assert.equal(scrypt_result, '0x78b512d6425a6fe9e45baf14603bfce1c875a6962db18cc12ecf4292dbd51da6')
-        
 	})
+
+	// it('should upload task code', async () => {
+        //     let codeBuf = fs.readFileSync("./scrypt-data/task.wasm")
+        //     let ipfsHash = (await fileSystem.upload(codeBuf, "task.wasm"))[0].hash
+            
+        //     assert.equal(ipfsHash, info.ipfshash)
+	// })
+	
+	// let scrypt_contract
+	// let scrypt_result
+
+	// it('should deploy test contract', async () => {
+        //     let MyContract = truffle_contract({
+	// 	abi: JSON.parse(fs.readFileSync("./scrypt-data/compiled/Scrypt.abi")),
+	// 	unlinked_binary: fs.readFileSync("./scrypt-data/compiled/Scrypt.bin"),
+        //     })
+        //     MyContract.setProvider(web3.currentProvider)
+
+        //     scrypt_contract = await MyContract.new(contractsConfig.incentiveLayer.address, contractsConfig.tru.address, contractsConfig.fileSystem.address, info.ipfshash, info.codehash, {from:account, gas:2000000})
+        //     let result_event = scrypt_contract.GotFiles()
+        //     result_event.watch(async (err, result) => {
+	// 	console.log("got event, file ID", result.args.files[0])
+	// 	result_event.stopWatching(data => {})
+	// 	let fileid = result.args.files[0]
+	// 	var lst = await tbFilesystem.getData(fileid)
+	// 	console.log("got stuff", lst)
+	// 	scrypt_result = lst[0]
+        //     })
+        //     tru.transfer(scrypt_contract.address, "100000000000", {from:account, gas:200000})
+	// })
+	
+	// it('should submit task', async () => {
+        //     scrypt_contract.submitData("testing", {from:account, gas:2000000})
+	// })
+
+	// it('wait for task', async () => {
+
+	//     await timeout(15000)
+	//     await mineBlocks(os.web3, 110)
+	//     await timeout(5000)
+	//     await mineBlocks(os.web3, 110)
+	//     await timeout(5000)
+            
+	//     await mineBlocks(os.web3, 110)
+	//     await timeout(5000)
+            
+        //     assert.equal(scrypt_result, '0x78b512d6425a6fe9e45baf14603bfce1c875a6962db18cc12ecf4292dbd51da6')
+            
+	// })
     })
 })

--- a/testWasmScrypt.json
+++ b/testWasmScrypt.json
@@ -1,0 +1,8 @@
+{
+    "minDeposit": "1",
+    "codeType": "WASM",
+    "storageType": "IPFS",
+    "codeFile": "/scrypt-data/task.wasm",
+    "reward": "0",
+    "files" : ["/input.data", "/output.data"]
+}


### PR DESCRIPTION
This is a small change related to the new scrypt test. I should've taken the time in review to analyze this more, and see that this test deviated from the other tests. The reason that is concerning is because it means it isn't checking the actual real world features. In this instance it was completely skipping the taskSubmitter and taskGiver parts, which means it isn't testing the actual user experience.

The more meta level discussion I'm hoping to have around this PR is that if we needed to modify the tests in order to make a specific feature work, then that is a strong signal that our current implementation is too inflexible to meet these needs, and should be enhanced. 

Right now `test/os-wasm-scrypt.js` is stuck on ocaml not finding the input data. Which is an easy fix, but I'm hoping to get more clarity on what the overall pipeline was intended to be.

@mrsmkl what was the planned the data input for this? According to `scrypthash.cpp` it should be a file named `input.data`. It seemed that you just wanted to pass in the string "testing" and then get a hash result. This seems like a reasonable thing to me, and should be a feature we can support.

