### PR TITLE
Naive Task Throttle

### DIFF
--- a/cli/cliLib.js
+++ b/cli/cliLib.js
@@ -40,12 +40,12 @@ module.exports.initTaskGiver = ({ os, account }) => {
 
 /** initialize solver with account address  */
 module.exports.initSolver = ({ os, account, test, recover }) => {
-    return os.solver.init(os.web3, account, os.logger, os.fileSystem, test, recover)
+    return os.solver.init(os.web3, account, os.logger, os.fileSystem, test, recover, os.throttle)
 }
 
 /** initialize verifier with account address  */
 module.exports.initVerifier = ({ os, account, test, recover }) => {
-    return os.verifier.init(os.web3, account, os.logger, os.fileSystem, test, recover)
+    return os.verifier.init(os.web3, account, os.logger, os.fileSystem, test, recover, os.throttle)
 }
 
 /** submit a task  */

--- a/os/kernel.js
+++ b/os/kernel.js
@@ -38,6 +38,7 @@ module.exports = async (configPath) => {
 	accounts: accounts,
 	logger: logger,
 	fileSystem: ipfsFileSystemHelper(config),
+	throttle: config["throttle"]
     }
 
 }

--- a/wasm-client/config.json
+++ b/wasm-client/config.json
@@ -8,5 +8,6 @@
 	"port": "5001",
 	"protocol": "http",
 	"merkleComputer": "../wasm-client/merkle-computer/"
-    }
+    },
+    "throttle" : 20
 }

--- a/wasm-client/solver.js
+++ b/wasm-client/solver.js
@@ -31,7 +31,7 @@ let games = {}
 let task_list = []
 
 module.exports = {
-    init: async (web3, account, logger, mcFileSystem, test = false, recover = -1) => {
+    init: async (web3, account, logger, mcFileSystem, test = false, recover = -1, throttle = 1) => {
 
         let bn = await web3.eth.getBlockNumber()
 
@@ -71,7 +71,7 @@ module.exports = {
 
         addEvent(incentiveLayer.TaskCreated, async (result) => {
 
-	        logger.log({
+	    logger.log({
                 level: 'info',
                 message: `Task has been posted. Checking for availability.`
             })
@@ -86,20 +86,23 @@ module.exports = {
             let initTaskHash = taskInfo.initTaskHash
 
             let solutionInfo = toSolutionInfo(await incentiveLayer.getSolutionInfo.call(taskID))
+
+	    if(Object.keys(tasks).length <= throttle) {
+		if (solutionInfo.solver == '0x0000000000000000000000000000000000000000') {
+
+                    let secret = "0x"+helpers.makeSecret(taskID)
+
+                    await depositsHelper(web3, incentiveLayer, tru, account, minDeposit)
+                    
+                    console.log("secret", secret, web3.utils.soliditySha3(secret))
+                    incentiveLayer.registerForTask(taskID, web3.utils.soliditySha3(secret), {from: account, gas: 500000})
+                    
+                    tasks[taskID] = {minDeposit: minDeposit}
+
+                    // tasks[taskID].secret = secret
+		}		
+	    }
             
-            if (solutionInfo.solver == '0x0000000000000000000000000000000000000000') {
-
-                let secret = "0x"+helpers.makeSecret(taskID)
-
-                await depositsHelper(web3, incentiveLayer, tru, account, minDeposit)
-                
-                console.log("secret", secret, web3.utils.soliditySha3(secret))
-                incentiveLayer.registerForTask(taskID, web3.utils.soliditySha3(secret), {from: account, gas: 500000})
-                
-                tasks[taskID] = {minDeposit: minDeposit}
-
-                // tasks[taskID].secret = secret
-            }
         })
 
         addEvent(incentiveLayer.SolverSelected, async (result) => {
@@ -177,11 +180,11 @@ module.exports = {
                 console.log("secret", secret)
                 await incentiveLayer.revealSolution(taskID, secret, vm.code, vm.input_size, vm.input_name, vm.input_data, {from: account, gas: 1000000})
                 await helpers.uploadOutputs(taskID, tasks[taskID].vm)
-              
+		
                 logger.log({
-		              level: 'info',
-		              message: `Revealed solution for task: ${taskID}. Outputs have been uploaded.`
-		            })
+		    level: 'info',
+		    message: `Revealed solution for task: ${taskID}. Outputs have been uploaded.`
+		})
             }
 	    
         })
@@ -190,11 +193,12 @@ module.exports = {
             let taskID = result.args.taskID	   
 	    
             if (tasks[taskID]) {
+		delete tasks[taskID]
                 await incentiveLayer.unbondDeposit(taskID, {from: account, gas: 100000})
                 logger.log({
                     level: 'info',
                     message: `Task ${taskID} finalized. Tried to unbond deposits.`
-                  })
+                })
 
             }
 

--- a/wasm-client/verifier.js
+++ b/wasm-client/verifier.js
@@ -35,7 +35,7 @@ let tasks = {}
 let games = {}
 
 module.exports = {
-    init: async (web3, account, logger, mcFileSystem, test = false, recover = -1) => {
+    init: async (web3, account, logger, mcFileSystem, test = false, recover = -1, throttle = 1) => {
         logger.log({
             level: 'info',
             message: `Verifier initialized`
@@ -87,59 +87,61 @@ module.exports = {
             let taskInfo = toTaskInfo(await incentiveLayer.getTaskInfo.call(taskID))
             taskInfo.taskID = taskID
 
-            // let storageType = result.args.storageType.toNumber()
+	    if (Object.keys(tasks).length <= throttle) {
+		// let storageType = result.args.storageType.toNumber()
 
-            let vm = await helpers.setupVMWithFS(taskInfo)
+		let vm = await helpers.setupVMWithFS(taskInfo)
 
-            let interpreterArgs = []
-            solution = await vm.executeWasmTask(interpreterArgs)
+		let interpreterArgs = []
+		solution = await vm.executeWasmTask(interpreterArgs)
 
-            logger.log({
-                level: 'info',
-                message: `Executed task ${taskID}. Checking solutions`
-            })
-
-            task_list.push(taskID)
-
-            tasks[taskID] = {
-                solverHash0: solverHash0,
-                solverHash1: solverHash1,
-                solutionHash: solution.hash,
-                vm: vm
-            }
-
-            if ((solverHash0 != solution.hash) ^ test) {
-
-                await depositsHelper(web3, incentiveLayer, tru, account, minDeposit)
-                let intent = helpers.makeSecret(solution.hash + taskID).substr(0, 62) + "00"
-                console.log("intent", intent)
-                tasks[taskID].intent0 = "0x" + intent
-                let hash_str = taskID + intent + account.substr(2) + solverHash0.substr(2) + solverHash1.substr(2)
-                await incentiveLayer.commitChallenge(web3.utils.soliditySha3(hash_str), { from: account, gas: 350000 })
-
-                logger.log({
+		logger.log({
                     level: 'info',
-                    message: `Challenged solution for task ${taskID}`
-                })
+                    message: `Executed task ${taskID}. Checking solutions`
+		})
 
-            }
+		task_list.push(taskID)
 
-            if ((solverHash1 != solution.hash) ^ test) {
+		tasks[taskID] = {
+                    solverHash0: solverHash0,
+                    solverHash1: solverHash1,
+                    solutionHash: solution.hash,
+                    vm: vm
+		}
 
-                await depositsHelper(web3, incentiveLayer, tru, account, minDeposit)
-                let intent = helpers.makeSecret(solution.hash + taskID).substr(0, 62) + "01"
-                tasks[taskID].intent1 = "0x" + intent
-                console.log("intent", intent)
-                let hash_str = taskID + intent + account.substr(2) + solverHash0.substr(2) + solverHash1.substr(2)
-                await incentiveLayer.commitChallenge(web3.utils.soliditySha3(hash_str), { from: account, gas: 350000 })
+		if ((solverHash0 != solution.hash) ^ test) {
 
-                logger.log({
-                    level: 'info',
-                    message: `Challenged solution for task ${taskID}`
-                })
+                    await depositsHelper(web3, incentiveLayer, tru, account, minDeposit)
+                    let intent = helpers.makeSecret(solution.hash + taskID).substr(0, 62) + "00"
+                    console.log("intent", intent)
+                    tasks[taskID].intent0 = "0x" + intent
+                    let hash_str = taskID + intent + account.substr(2) + solverHash0.substr(2) + solverHash1.substr(2)
+                    await incentiveLayer.commitChallenge(web3.utils.soliditySha3(hash_str), { from: account, gas: 350000 })
 
-            }
+                    logger.log({
+			level: 'info',
+			message: `Challenged solution for task ${taskID}`
+                    })
 
+		}
+
+		if ((solverHash1 != solution.hash) ^ test) {
+
+                    await depositsHelper(web3, incentiveLayer, tru, account, minDeposit)
+                    let intent = helpers.makeSecret(solution.hash + taskID).substr(0, 62) + "01"
+                    tasks[taskID].intent1 = "0x" + intent
+                    console.log("intent", intent)
+                    let hash_str = taskID + intent + account.substr(2) + solverHash0.substr(2) + solverHash1.substr(2)
+                    await incentiveLayer.commitChallenge(web3.utils.soliditySha3(hash_str), { from: account, gas: 350000 })
+
+                    logger.log({
+			level: 'info',
+			message: `Challenged solution for task ${taskID}`
+                    })
+
+		}		
+		
+	    }
         })
 
         addEvent(incentiveLayer.EndChallengePeriod, async result => {
@@ -171,6 +173,7 @@ module.exports = {
 	    
             if (tasks[taskID]) {
                 await incentiveLayer.unbondDeposit(taskID, {from: account, gas: 100000})
+		delete tasks[taskID]
                 logger.log({
                     level: 'info',
                     message: `Task ${taskID} finalized. Tried to unbond deposits.`


### PR DESCRIPTION
This resolves #72 in an extremely simplistic fashion. The parts that I don't think will change is how the throttle count is passed from the config file to the solver/verifier. 

For now it simply checks the count of tasks it is currently working with before commiting to solve/verify, and makes sure to delete those tasks after finalization. The next iteration would ideally differentiate between idle tasks and non idle tasks with the calls to the VM and RAM being the biggest bottlenecks for task throughput. 